### PR TITLE
PLAN-136 do not reopen connection on game mount if its already open

### DIFF
--- a/services/app/src/pages/game/Game.jsx
+++ b/services/app/src/pages/game/Game.jsx
@@ -42,7 +42,9 @@ const Game = () => {
   }
 
   useEffect(() => {
-    connectToWs();
+    if(ws?.readyState !== wsReadyStates.OPEN) {
+      connectToWs();
+    }
   }, []);
 
   const skipMove = useCallback((playerId) => {


### PR DESCRIPTION
This change should only make a difference in Safari browser, all the others should work the same as it was before